### PR TITLE
Fix warping to an undefined location

### DIFF
--- a/src/classes/Utils.as
+++ b/src/classes/Utils.as
@@ -120,7 +120,10 @@ class Utils {
     }
 
     // Warps the player to a certain course.
+    // Returns the location Mario warped to. Returns undefined if this location doesn't exist.
     public function warp(title, playerX, playerY, cameraX, cameraY, isCommand) {
+        var warpedLocation = undefined;
+
         if (isCommand == undefined) {
             isCommand = true;
         }
@@ -134,10 +137,14 @@ class Utils {
 
         title = this.getWarpFromAlias(title);
 
-        setTimeout(function() {
-            _root.changecourse("StarIn", title, cameraX, cameraY, playerX, playerY, undefined, isCommand);
-        }, this.getWarpTimeout());
+        if (title != undefined) {
+            warpedLocation = title;
+            setTimeout(function() {
+                _root.changecourse("StarIn", title, cameraX, cameraY, playerX, playerY, undefined, isCommand);
+            }, this.getWarpTimeout());
+        }
 
+        return warpedLocation;
     }
 
     // Interprets a sent alias and returns a warp that the game understands.
@@ -146,15 +153,26 @@ class Utils {
 
         for (i = 0; i < this.worldList.length; i++) {
             if (this.worldList[i].hasWarps()) {
-                var warp = this.worldList[i].getWarps()[alias];
+                var worldWarps = this.worldList[i].getWarps();
+                var warp = worldWarps[alias];
             
                 if (!(warp == undefined || warp == '')) {
                     return warp;
                 }
+                else {
+                    // We check if the associative array contains the actual warp name
+                    // and return it if we find it
+                    var elem;
+                    for (elem in worldWarps) {
+                        if (alias == worldWarps[elem]) {
+                            return alias;
+                        }
+                    }
+                }
             }
         }
 
-        return alias;
+        return undefined;
     }
 
     // Resets the stats of the coins. Makes all collected coins re-appear.

--- a/src/classes/codes/Warp.as
+++ b/src/classes/codes/Warp.as
@@ -9,21 +9,25 @@ _root.codeManager.add(new Code('warp w', 'Warps the player to a specific section
     if (level != undefined) {
 
         var definedCoordinates = (player_x != undefined && player_y != undefined);
+        var warpedLocation = undefined;
 
         if (definedCoordinates) {
             if (camera_x == undefined)
                 camera_x = player_x;
             if (camera_y == undefined)
                 camera_y = player_y;
-            _root.utils.warp(command[1], player_x, player_y, camera_x, camera_y, false);
+            warpedLocation = _root.utils.warp(command[1], player_x, player_y, camera_x, camera_y, false);
         } else {
-            _root.utils.warp(command[1], 0, 0, 0, 0, true);
+            warpedLocation = _root.utils.warp(command[1], 0, 0, 0, 0, true);
         }
 
-        setTimeout(function() {
-            _root.textManager.send('message', 'Player has been warped to ' + command[1] + '.');
-        }, _root.utils.getAfterWarpTimeout());
-
+        if (warpedLocation != undefined) {
+            setTimeout(function() {
+                _root.textManager.send('message', 'Player has been warped to ' + command[1] + '.');
+            }, _root.utils.getAfterWarpTimeout());
+        }
+        else {
+            _root.textManager.send('message', 'The warp location is invalid.');
+        }
     }
-
 }));

--- a/src/classes/worlds/WorldEotMK.as
+++ b/src/classes/worlds/WorldEotMK.as
@@ -25,6 +25,7 @@ class WorldEotMK {
         dict["eotmk"] = "K-1";
         dict["eotmkr1"] = "K-1";
         dict["eotmkr2"] = "K-2";
+        dict["eotmkr3"] = "K-3";
 
         return dict;
     }


### PR DESCRIPTION
Before, if the user types a wrong warp course, he would be warped into an undefined course that's completely empty.
Now, the user is prevented from warping, and he receives a `The warp location is invalid` message.