### PR TITLE
Python3 usage in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 frame6:
-	python src/_generator.py
+	python3 src/_generator.py


### PR DESCRIPTION
- Usage of `python3` instead of Python 2 in the makefile code generation command, for stability purposes